### PR TITLE
Remove Vector from default LocalSettings

### DIFF
--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -101,11 +101,6 @@ $wgAuthenticationTokenVersion = "1";
 $wgUpgradeKey = "t8qu09t9uw09ti09itq092t3j";
 $wgSecretKey = "a5dca55190e1c3927e098c317dd74e85c7eced36f959275114773b188fbabdbc";
 
-## Skins
-
-$wgDefaultSkin = "vector";
-wfLoadSkin( 'Vector' );
-
 ## Permissions
 
 $wgGroupPermissions['*']['noratelimit'] = true;


### PR DESCRIPTION
Which skin is used should be up to the user. And manage in their
main `LocalSettings.php` file – below the include for `.docker/LocalSettings.php`.

This way the default page after cloning MediaWiki will be MediaWiki's fallback skin informing the user to add `wfLoadSkin()` to LocalSettings.php.

Whereas right now, if Vector is not cloned, the user gets a PHP-level fatal error saying mediawiki/skins/Vector does not exist.