### PR TITLE
build: Add Travis CI config to test installation process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+dist: trusty
+language: bash
+services:
+  - docker
+addons:
+  hosts:
+    - default.web.mw.localhost
+    - proxy.mw.localhost
+    - phpmyadmin.mw.localhost
+    - graphite.mw.localhost
+install:
+  - git clone --depth=50 --branch=master https://github.com/wikimedia/mediawiki.git ~/mediawiki
+  - echo -e '<?php\nrequire_once __DIR__ . "/.docker/LocalSettings.php";\n' > ~/mediawiki/LocalSettings.php
+  - echo -e 'DOCKER_MW_PATH=~/mediawiki\nDOCKER_MW_PORT=8080\n' > local.env
+script:
+  - ./up
+  - cat .env
+  # Once to show useful output
+  - curl -i 'http://default.web.mw.localhost:8080'
+  # Again for the exit code to fail the build if needed (curl, why can't we have both?)
+  - curl -s --fail --show-error 'http://default.web.mw.localhost:8080'

--- a/up
+++ b/up
@@ -37,7 +37,10 @@ docker-compose exec "web" chown application:application //var/www/mediawiki
 docker-compose exec "web" chown application:application //var/www/mediawiki/vendor
 # Permission for composer-cache volume
 docker-compose exec "web" chown application:application //cache/composer
-docker-compose exec --user application "web" composer update --working-dir //var/www/mediawiki
+# Wrap in 'sh -c' because it seems that for some reason the exit code from
+# 'composer update' is wrongly reported as an error when executed by docker
+# directly. Without this wrap, it fails in Travis CI.
+docker-compose exec --user application "web" sh -c 'composer update --working-dir /var/www/mediawiki'
 
 echo "Waiting for the db server to finish starting"
 docker-compose exec "web" //srv/wait-for-it.sh db:3306


### PR DESCRIPTION
Test the installation process on Travis. An error during any
step of the installation process will be caught by this.

In addition, it also makes sure the default HTTP endpoint
responds with a status code that isn't 4xx or 5xx.

Had to make one change to make it pass. The 'docker-composer exec'
to run 'composer update' was failing with an exit code of 129
for unclear reasons. This seems to be a common problem with
PHP-based programs in Docker on Linux. Successfully worked around
by invoking indirectly via 'sh -c'.