### PR TITLE
mediawiki: Fix wgFavicon to use absolute script path

### DIFF
--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -35,7 +35,7 @@ $wgScriptPath = "";
 
 $wgSitename = "docker-$dockerDb";
 $wgMetaNamespace = "Project";
-$wgFavicon = "./.docker/favicon.ico";
+$wgFavicon = "{$wgScriptPath}/.docker/favicon.ico";
 
 $wgUploadDirectory = "{$IP}/images/docker/{$dockerDb}";
 $wgUploadPath = "{$wgScriptPath}/images/docker/{$dockerDb}";


### PR DESCRIPTION
The relative directory meant that in some cases, it will use
a path relative to the current (sub)directory, which led to a
404 Not Found.


Minor bug fix, extracted from https://github.com/Krinkle/mediawiki-docker-dev/commit/cd4b2170433b1e2183ea4750478b5d18f4c72836.