### PR TITLE
Set MW_INSTALL_PATH inside the web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     image: webdevops/${PHPORHHVM}-${WEBSERVER}${DOCKERPHPDEV}:${RUNTIMEVERSION}
     environment:
      - WEB_DOCUMENT_ROOT=/var/www/mediawiki
+     # Used by various maintenance scripts to find MediaWiki.
+     - MW_INSTALL_PATH=/var/www/mediawiki
      - VIRTUAL_HOST=*.web.mw.localhost
      - PHP_DEBUGGER=xdebug
      - XDEBUG_REMOTE_AUTOSTART=1


### PR DESCRIPTION
Helps with the running of various maintenance scripts that
need to find MediaWiki.

Minor improvement, extracted from https://github.com/Krinkle/mediawiki-docker-dev/commit/cd4b2170433b1e2183ea4750478b5d18f4c72836.