### PR TITLE
Use sub directory for MediaWiki

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,6 @@ script:
   - ./up
   - cat .env
   # Once to show useful output
-  - curl -i 'http://default.web.mw.localhost:8080'
+  - curl -I -L 'http://default.web.mw.localhost:8080'
   # Again for the exit code to fail the build if needed (curl, why can't we have both?)
   - curl -s --fail --show-error 'http://default.web.mw.localhost:8080'

--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -31,7 +31,7 @@ $wgDBprefix = "";
 $wgDBTableOptions = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 
 ## Site settings
-$wgScriptPath = "";
+$wgScriptPath = "/mediawiki";
 
 $wgSitename = "docker-$dockerDb";
 $wgMetaNamespace = "Project";

--- a/config/mediawiki/index.php
+++ b/config/mediawiki/index.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * This file is copied by ./up to web://var/www/index.php.
+ *
+ * This entry point allows MediaWiki to handle requests for "/".
+ */
+
+require __DIR__ . '/mediawiki/index.php';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,9 @@ services:
   web:
     image: webdevops/${PHPORHHVM}-${WEBSERVER}${DOCKERPHPDEV}:${RUNTIMEVERSION}
     environment:
-     - WEB_DOCUMENT_ROOT=/var/www/mediawiki
+     - WEB_DOCUMENT_ROOT=/var/www
      # Used by various maintenance scripts to find MediaWiki.
+     # Also required for /var/www/index.php - https://phabricator.wikimedia.org/T153882
      - MW_INSTALL_PATH=/var/www/mediawiki
      - VIRTUAL_HOST=*.web.mw.localhost
      - PHP_DEBUGGER=xdebug

--- a/up
+++ b/up
@@ -37,6 +37,9 @@ docker-compose exec "web" chown application:application //var/www/mediawiki
 docker-compose exec "web" chown application:application //var/www/mediawiki/vendor
 # Permission for composer-cache volume
 docker-compose exec "web" chown application:application //cache/composer
+# Add document root index file (NOTE: docker-compose lacks a "cp" command)
+docker cp config/mediawiki/index.php "$(docker-compose ps -q web)"://var/www/index.php
+docker-compose exec "web" chown application:application //var/www/index.php
 # Wrap in 'sh -c' because it seems that for some reason the exit code from
 # 'composer update' is wrongly reported as an error when executed by docker
 # directly. Without this wrap, it fails in Travis CI.


### PR DESCRIPTION
Instead localhost/index.php, it is now localhost/mediawiki/index.php.

Keep the localhost/ redirect working by adding a wrapper in the
document root that loads MediaWiki. This is essentially the
same technique WordPress popularises and works better than
writing a rewrite-rule, because we'd have to maintain those
for each web server backend separately, whereas right now our
setup is webserver agnostic. The docker-compose can be tied
to Linux distribution, web server type, or PHP version. They
provide the same base interface from webdevops/*.

Update Travis CI:

* Follow the redirect in its cURL request, currently it was only
  showing the headers for the 301 redirect from the document root.

* Change -i to -I so that it keeps showing headers only instead
  of full HTML. Previously -i allowed it to show a body, but there
  was no body for the redirect. Now that we follow the redirect,
  switch to -I so that we still don't dump the body.

Fixes addshore/mediawiki-docker-dev#28.