### PR TITLE
Clarify root execution in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ If you don't want to use the default port of 8080 and the default mediawiki path
 
 https://docs.docker.com/compose/install/
 
-If you don't want to run the container as root, you will have to add your user to the docker group:
+If you want to avoid logging in as root or sudo commands, you will have to add your user to the docker group:
 https://askubuntu.com/questions/477551/how-can-i-use-docker-without-sudo#477554
+
+Note that this does not mean your containers will not run as root. This is a different setting and it is either set in the Dockerfile of the image (see USER setting) or during the execution of the image (-u/--user of docker-run, user: setting of docker compose)
 
 #### 2) Clone this repository
 


### PR DESCRIPTION
Make it clear that adding a user to `docker` has nothing to do with the actual UID used for executing the container.