### PR TITLE
[WIP] enable browser tests (via access from docker network)

### DIFF
--- a/browsertest
+++ b/browsertest
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+# create user needed for certain edit actions (only has effect on the first go)
+docker-compose -f docker-compose.yml -f docker-compose.browsertest.yml \
+	run --rm web php //var/www/mediawiki/maintenance/createAndPromote.php --wiki default --bureaucrat --sysop --bot selenium test1234 \
+	|| true
+
+docker-compose -f docker-compose.yml -f docker-compose.browsertest.yml \
+	run --rm seleniumtests node_modules/.bin/wdio tests/selenium/wdio.conf.js --mochaOpts.timeout=60000 --host selenium

--- a/default.env
+++ b/default.env
@@ -13,5 +13,14 @@ IDELOCALHOST=10.0.75.1
 # Location of the mediawiki repo on your machine
 DOCKER_MW_PATH=/srv/dev/git/gerrit/mediawiki
 
+# Location of mediawiki building blocks on your machine
+SKIN_VECTOR_PATH=/srv/dev/git/gerrit/Vector
+EXT_ADVANCEDSEARCH_PATH=/srv/dev/git/gerrit/AdvancedSearch
+EXT_CIRRUSSEARCH_PATH=/srv/dev/git/gerrit/CirrusSearch
+EXT_ELASTICA_PATH=/srv/dev/git/gerrit/Elastica
+EXT_EVENTLOGGING_PATH=/srv/dev/git/gerrit/EventLogging
+
+SELENIUM_LOG_PATH=/tmp/selenium-logs
+
 # Port to serve everything up through
 DOCKER_MW_PORT=8080

--- a/docker-compose.browsertest.yml
+++ b/docker-compose.browsertest.yml
@@ -1,0 +1,50 @@
+version: '2'
+
+services:
+  web:
+    # additional volumes (https://docs.docker.com/compose/extends/#adding-and-overriding-configuration)
+    volumes:
+      - "${SKIN_VECTOR_PATH}:/var/www/mediawiki/skins/Vector"
+      - "${EXT_ADVANCEDSEARCH_PATH}:/var/www/mediawiki/extensions/AdvancedSearch"
+      - "${EXT_CIRRUSSEARCH_PATH}:/var/www/mediawiki/extensions/CirrusSearch"
+      - "${EXT_ELASTICA_PATH}:/var/www/mediawiki/extensions/Elastica"
+      - "${EXT_EVENTLOGGING_PATH}:/var/www/mediawiki/extensions/EventLogging"
+    depends_on:
+      - elasticsearch
+
+  phpmyadmin:
+    image: hello-world
+
+  graphite-statsd:
+    image: hello-world
+
+  # to update indexes
+  # docker-compose ... run web php /var/www/mediawiki/extensions/CirrusSearch/maintenance/updateSearchIndexConfig.php
+  # docker-compose ... run web php /var/www/mediawiki/extensions/CirrusSearch/maintenance/forceSearchIndex.php
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.5.0
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+
+  seleniumtests:
+    image: "node:6"
+    environment:
+      - "MW_SERVER=http://web"
+      - "MW_SCRIPT_PATH=/mediawiki"
+      - "MEDIAWIKI_USER=selenium"
+      - "MEDIAWIKI_PASSWORD=test1234"
+    command: echo 'invoke me through ./browsertest'
+    working_dir: /app
+    volumes:
+      - "${DOCKER_MW_PATH}:/app"
+      - "${EXT_ADVANCEDSEARCH_PATH}:/app/extensions/AdvancedSearch"
+      - "${SELENIUM_LOG_PATH}:/app/log"
+    depends_on:
+      - selenium
+
+  selenium:
+    image: selenium/standalone-chrome
+    shm_size: '2gb'
+    depends_on:
+      - web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
      - ./config/hhvm/server.ini:/etc/hhvm/server.ini:ro
      - ./scripts/wait-for-it.sh:/srv/wait-for-it.sh:ro
      - mw-images:/var/www/mediawiki/images/docker
+    working_dir: /var/www/mediawiki
+
   graphite-statsd:
     image: hopsoft/graphite-statsd
     environment:
@@ -83,6 +85,8 @@ services:
       - "${DOCKER_MW_PORT}:80"
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+    depends_on:
+      - web
 
 volumes:
   sql-data-master:


### PR DESCRIPTION
Is rather opinionated and advancedSearch-centric - any idea how to allow capabilities but keeping them optional welcome. (I might want browser tests but not advancedsearch, I might want elasticsearch but not browser tests, ...)

- should we make the vector (arguably the most popular skin) setup part of CI by default?
- should we make the extension loading depending on their presence (mounted or not)?

Covers #47

But first let's verify that it works on more than one system. @gbirke 

Make sure your mediawiki's checkout LocalSettings.php does nothing but
point to .docker/LocalSettings.php (e.g. no `define( "MW_DB", "default" );` in there)