### PR TITLE
Docs for composer install with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ git clone https://gerrit.wikimedia.org/r/mediawiki/skins/Vector /srv/dev/git/ger
 
 #### 4) Run `composer install` for MediaWiki
 
+Either on your host machine or with Docker, inside the `/srv/dev/git/gerrit/mediawiki` directory:
+
+```
+docker run -it --rm --user $(id -u):$(id -g) -v ~/.composer:/composer -v $(pwd):/app docker.io/composer install
+```
+
 #### 5) Create a basic LocalSettings.php
 
 The .docker/LocalSettings.php file will exist within the containers running Mediawiki.


### PR DESCRIPTION
Add example command on how to run `composer install` with a docker image
instead of running it on your host machine.