### PR TITLE
logs-tail: Add default help when required parameter is missing

### DIFF
--- a/logs-tail
+++ b/logs-tail
@@ -2,4 +2,20 @@
 # Usage: logs-tail debug.log
 set -eu
 
+if [ -z "${1:-}" ]; then
+	echo "Usage: logs-tail <file>"
+	echo ""
+	echo "Options:"
+	echo ""
+	echo "<file>"
+	echo "    File path relative to /var/log/mediawiki/,"
+	echo "    for example 'debug.log'."
+	echo ""
+	echo "Exampless:"
+	echo ""
+	echo "    $ logs-tail debug.log"
+	echo ""
+	exit 1
+fi
+
 docker-compose exec "web" tail -f //var/log/mediawiki/$1


### PR DESCRIPTION
This is an improvement over the current response:

```
./logs-tail: line 5: $1: unbound variable
```

This often leaves me thinking that it requires a parameter for the
container ("web") or the wiki ("default"), until I eventually
cat the script and remember it require a file path.