### PR TITLE
Change default password to 'dockerpass'

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Without such a bash alias you will have the run the scripts from within the medi
 
 Create and start containers.
 
-This includes setting up a default wiki @ http://default.web.mw.localhost:8080 with an "admin" user that has password "adminpass".
+This includes setting up a default wiki @ http://default.web.mw.localhost:8080 with an "admin" user that has password "dockerpass".
 
 You can choose the spec of the system that the up command will set up by using a custom .env file called local.env and customizing the variables.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Without such a bash alias you will have the run the scripts from within the medi
 
 Create and start containers.
 
-This includes setting up a default wiki @ http://default.web.mw.localhost:8080 with an "admin" user that has password "dockerpass".
+This includes setting up a default wiki @ http://default.web.mw.localhost:8080 with an "Admin" user that has password "dockerpass".
 
 You can choose the spec of the system that the up command will set up by using a custom .env file called local.env and customizing the variables.
 

--- a/config/mediawiki/installdbs
+++ b/config/mediawiki/installdbs
@@ -7,7 +7,7 @@ then
 fi
 
 # Install the base Mediawiki tables on the db server & remove the generated LocalSettings.php
-php /var/www/mediawiki/maintenance/install.php --dbuser root --dbpass toor --dbname $1 --dbserver db-master --lang en --pass adminpass docker-$1 admin
+php /var/www/mediawiki/maintenance/install.php --dbuser root --dbpass toor --dbname $1 --dbserver db-master --lang en --pass dockerpass docker-$1 admin
 rm /var/www/mediawiki/LocalSettings.php
 
 # Move back the old LocalSettings if we had moved one!


### PR DESCRIPTION
The default of 'adminpass' is no longer accepted by MediaWiki.

It results in a prompt about how users with this level of access should have "_a password at least 10 chars, and not in a list of common passwords_".