### PR TITLE
Add documentation on docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 local.env
+docker-compose.override.yml
 .env
 .hosts
 .hosts.tmp

--- a/README.md
+++ b/README.md
@@ -236,6 +236,30 @@ To do so you need to set `IDELOCALHOST` in you local.env file to the IP of your 
 
 xdebug connections will then be sent to this IP address on port 9000.
 
+## Overriding / Extending
+
+You can add additional services, or modify current services, by creating a `docker-compose.override.yml` file ([docs](https://docs.docker.com/compose/extends/)). For example, to add a Redis service, add these contents to `docker-compose.override.yml`:
+
+``` yaml
+version: '2'
+services:
+  redis:
+    image: redis
+```
+
+To modify a current service, for example to specify volume caching for macOS:
+
+``` yaml
+version: '2'
+services:
+  web:
+    volumes:
+      - "${DOCKER_MW_PATH}:/var/www/mediawiki:cached"
+```
+
+Note that the other volumes for the `web` service will be merged, so you don't need to specify every volume mapping from the main `docker-compose.yml` file in your `docker-compose.override.yml` file.
+
+
 ## TODO
 
  - FIX HHVM strict mode


### PR DESCRIPTION
Also relevant to #71. But for now, this is a quick way to add/modify services without polluting the git tree.