### PR TITLE
docs: Update RUNTIMEVERSION comment for ubuntu-18 and php 7.3

### DIFF
--- a/default.env
+++ b/default.env
@@ -21,11 +21,12 @@ PHPORHHVM=php
 # for valid values.
 #
 # For example:
-# - 'latest' (alias to ubuntu-16.04)
+# - 'latest' (alias to ubuntu-18.04)
+# - 'ubuntu-18.04' (Ubuntu 18 Bionic LTS, provides PHP 7.2).
 # - 'ubuntu-16.04' (Ubuntu 16 Xenial LTS, provides PHP 7.0).
-# - '7.2' (based on Debian 8 Jessie)
-# - '7.1' (based on Debian 8 Jessie)
-# - '7.0' (based on Debian 8 Jessie)
+# - '7.3' (based on Debian 9 Stretch)
+# - '7.2' (based on Debian 9 Stretch)
+# - '7.1' (based on Debian 9 Stretch)
 RUNTIMEVERSION=latest
 
 # Value for XDEBUG_REMOTE_HOST


### PR DESCRIPTION
* The `latest` tag from webdevops.io now tracks ubuntu-18.04.
* The PHP official images now use Debian 9 Stretch.
* Mention php 7.3.
* Don't mention php 7.0 (EOL as of 2 months ago).