### PR TITLE
Enable volume caching by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Many aspect of the container, including the port and MediaWiki path, can be cust
 by creating a `local.env` in this directory, in which to override one or more variables
 from `default.env`.
 
-There is a setup script that you can run with `INSTALL_DIR=~/src ./setup.sh` if you already have Docker 
+There is a setup script that you can run with `INSTALL_DIR=~/src ./setup.sh` if you already have Docker
 installed and want to skip the manual steps. Note that `INSTALL_DIR` is the parent directory where MediaWiki
 core will be downloaded, so in the example above you would end up with a codebase at `~/src/mediawiki`.
 
@@ -251,14 +251,14 @@ services:
     image: redis
 ```
 
-To modify a current service, for example to specify volume caching for macOS:
+To modify a current service, for example to [try a different volume caching for macOS](https://docs.docker.com/docker-for-mac/osxfs-caching/) like `:delegated` instead of `:cached` ([file reference](https://docs.docker.com/compose/compose-file/#volumes)):
 
-``` yaml
+```yaml
 version: '2'
 services:
   web:
     volumes:
-      - "${DOCKER_MW_PATH}:/var/www/mediawiki:cached"
+      - "${DOCKER_MW_PATH}:/var/www/mediawiki:delegated"
 ```
 
 Note that the other volumes for the `web` service will be merged, so you don't need to specify every volume mapping from the main `docker-compose.yml` file in your `docker-compose.override.yml` file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,12 +68,12 @@ services:
     depends_on:
      - db-configure
     volumes:
-     - "${DOCKER_MW_PATH}:/var/www/mediawiki"
+     - "${DOCKER_MW_PATH}:/var/www/mediawiki:cached"
      - ./config/mediawiki:/var/www/mediawiki/.docker:ro
      - ./config/hhvm/php.ini:/etc/hhvm/php.ini:ro
      - ./config/hhvm/server.ini:/etc/hhvm/server.ini:ro
      - ./scripts/wait-for-it.sh:/srv/wait-for-it.sh:ro
-     - mw-images:/var/www/mediawiki/images/docker
+     - mw-images:/var/www/mediawiki/images/docker:delegated
   graphite-statsd:
     image: hopsoft/graphite-statsd
     environment:


### PR DESCRIPTION
This makes a significant difference in terms of responsiveness.

Loading Special:Blankpage three times, measuring TTFB via performance.timing.

Before, between 2000 and 2300.
After, between 1300 and 1700.

Thanks @kostajh!