### PR TITLE
Make sure that hosts of additional sites are accessible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,9 @@ services:
      - ./config/hhvm/server.ini:/etc/hhvm/server.ini:ro
      - ./scripts/wait-for-it.sh:/srv/wait-for-it.sh:ro
      - mw-images:/var/www/mediawiki/images/docker:delegated
+    extra_hosts:
+     - "default.web.mw.localhost:127.0.0.1"
+
   graphite-statsd:
     image: hopsoft/graphite-statsd
     environment:

--- a/hosts-add
+++ b/hosts-add
@@ -4,4 +4,7 @@ set -eu
 # Keep note of host names, so that users can use
 # ./hosts-sync to test their current state and
 # attempt to save it manually.
-echo "127.0.0.1 $1 # mediawiki-docker-dev" >> .hosts
+HOSTLINE="127.0.0.1 $1 # mediawiki-docker-dev"
+
+echo "$HOSTLINE" >> .hosts
+docker-compose exec "web" sh -c "echo '$HOSTLINE' >> /etc/hosts"

--- a/resume
+++ b/resume
@@ -4,3 +4,6 @@ set -eu
 echo "Containers are starting"
 
 docker-compose start
+
+HOSTS=`cat .hosts`
+docker-compose exec "web" sh -c "echo '$HOSTS' >> /etc/hosts"


### PR DESCRIPTION
The changes in this patch try to make sure, that additional sites are
reachable using the host addresses given to them. This is especially
revlevant for multi-wiki setups where wikis should be able to access
each others API.