### PR TITLE
Set default config for required $wgCacheDirectory

### DIFF
--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -73,6 +73,7 @@ $wgUploadDirectory = "{$IP}/images/docker/{$dockerDb}";
 $wgUploadPath = "{$wgScriptPath}/images/docker/{$dockerDb}";
 
 $wgTmpDirectory = "{$wgUploadDirectory}/tmp";
+$wgCacheDirectory = "{$wgUploadDirectory}/cache";
 
 $wgStatsdServer = "graphite-statsd";
 


### PR DESCRIPTION
$wgCacheDirectory is now required and it not being set leads to warnings
in the PHP error log.

Putting the cache directory by default next to the temporary directory
seems intuitive.

See for reference:
https://phabricator.wikimedia.org/T218207
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/529057