### PR TITLE
addsite: run installdbs as the application user to fix logging

### DIFF
--- a/addsite
+++ b/addsite
@@ -13,6 +13,6 @@ echo "Creating cache directory"
 docker-compose exec --user application "web" mkdir -p //var/www/mediawiki/images/docker/$1/cache
 
 echo "Running install.php script"
-docker-compose exec --user root "web" bash //var/www/mediawiki/.docker/installdbs $1
+docker-compose exec --user application "web" bash //var/www/mediawiki/.docker/installdbs $1
 
 ./hosts-add $1.web.mw.localhost

--- a/config/mediawiki/LocalSettings.php
+++ b/config/mediawiki/LocalSettings.php
@@ -79,7 +79,7 @@ $wgStatsdServer = "graphite-statsd";
 
 ## Dev & Debug
 
-$dockerLogDirectory = "/var/log/mediawiki/";
+$dockerLogDirectory = "/var/log/mediawiki";
 $wgDebugLogFile = "$dockerLogDirectory/debug.log";
 
 ini_set( 'xdebug.var_display_max_depth', -1 );


### PR DESCRIPTION
Currently, the installdbs script is run as the root user in addsite.
This doesn't appear to be necessary for any specific reason, and results
in the application not having permission to write to the created log
file. Updating to run as the application user fixes logging and doesn't
appear to have any negative side effects.

Hygiene: Also removes an extra trailing slash from the
$dockerLogDirectory value set in config/mediawiki/LocalSettings.php.