### PR TITLE
travis: chown mediawiki and LocalSettings.php

### DIFF
--- a/create
+++ b/create
@@ -22,6 +22,10 @@ echo >> .env
 echo "Containers are starting"
 docker-compose up -d
 
+# Change owners
+docker-compose exec "web" chown application:application //var/www/mediawiki
+docker-compose exec "web" chown application:application //var/www/mediawiki/LocalSettings.php
+
 # Add document root index file (NOTE: docker-compose lacks a "cp" command)
 docker cp config/mediawiki/index.php "$(docker-compose ps -q web)"://var/www/index.php
 docker-compose exec "web" chown application:application //var/www/index.php

--- a/setup.sh
+++ b/setup.sh
@@ -15,4 +15,3 @@ cat > LocalSettings.php <<EOL
 require_once __DIR__ . '/.docker/LocalSettings.php';
 wfLoadSkin( 'Vector' );
 EOL
-chmod 777 LocalSettings.php


### PR DESCRIPTION
travis does its job as UID 2000(travis) who does not exist in the container.
So the owner of `/var/www/mediawiki` and `/var/www/mediawiki/LocalSettings.php` was also 2000 before this patch

Closes https://github.com/addshore/mediawiki-docker-dev/issues/101