### PR TITLE
Automatically add extra_hosts for added sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docker-compose.override.yml
 .hosts
 .hosts.tmp
 .hosts.tmp.bak
+docker-compose.override-sites.yml

--- a/create
+++ b/create
@@ -20,7 +20,7 @@ echo >> .env
 
 # Start Containers
 echo "Containers are starting"
-docker-compose up -d
+docker-compose -f docker-compose.yml -f docker-compose.override-sites.yml up -d
 
 # Change owners
 docker-compose exec "web" chown application:application //var/www/mediawiki

--- a/docker-compose.override-sites.initial.yml
+++ b/docker-compose.override-sites.initial.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+  web:
+    extra_hosts:
+     - "default.web.mw.localhost:${IDELOCALHOST}"

--- a/hosts-add
+++ b/hosts-add
@@ -5,3 +5,10 @@ set -eu
 # ./hosts-sync to test their current state and
 # attempt to save it manually.
 echo "127.0.0.1 $1 # mediawiki-docker-dev" >> .hosts
+
+DOCKER_COMPOSE_OVERRIDES='docker-compose.override-sites.yml'
+if [ ! -f "$DOCKER_COMPOSE_OVERRIDES" ]; then
+    cp docker-compose.override-sites.initial.yml $DOCKER_COMPOSE_OVERRIDES
+fi
+
+echo "     - \"$1:\${IDELOCALHOST}\"" >> $DOCKER_COMPOSE_OVERRIDES

--- a/resume
+++ b/resume
@@ -3,4 +3,4 @@ set -eu
 
 echo "Containers are starting"
 
-docker-compose start
+docker-compose -f docker-compose.yml -f docker-compose.override-sites.yml up -d


### PR DESCRIPTION
Naive attempt at making `curl 'http://[SOME SITE].web.mw.localhost:8080/'`
work when run inside the web container, i.e. after `mw-docker-dev bash`.
This allows for better wiki to wiki communication within the docker
network.

Problems:
* requires restart to take effect
* explicitly specifying the extra docker-compose.yml is annoying
* the way the extra overrides file is generated is super hacky but that
  can be improved