### PR TITLE
Add image pulling to create script

### DIFF
--- a/create
+++ b/create
@@ -18,6 +18,10 @@ touch local.env
 cat local.env >> .env
 echo >> .env
 
+# Pull latest version of specified containers
+echo "Pulling latest containers"
+docker-compose pull
+
 # Start Containers
 echo "Containers are starting"
 docker-compose up -d


### PR DESCRIPTION
Currently after running the automatic setup procedure there can be the problem that the "latest" php image (or any of the others hasn't been pulled) and is therefore stale.

Adding pulling to the create script will allow this to work out of the box.

An alternative solution would be to add it to `setup.sh` but this would mean that e.g. as the `latest` tagged images get stale a user unfamiliar with docker may not notice and confusingly get stale images.

A possible follow up to the PR could perhaps be removing the warning in README.md about `latest` as RUNTIMEVERSION not working. I'm unclear if this is the only problem that is trying to warm the users about though.