### PR TITLE
Set DOCKER_MW_PATH on setup.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
 install:
   - INSTALL_DIR=$HOME ./setup.sh
   - echo -e '<?php\nrequire_once __DIR__ . "/.docker/LocalSettings.php";\n' > ~/mediawiki/LocalSettings.php
-  - echo -e 'DOCKER_MW_PATH=~/mediawiki\nDOCKER_MW_PORT=8080\n' > local.env
 script:
   - ./create
   - cat .env

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,12 @@ mkdir -p "$INSTALL_DIR"
 git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/core "$INSTALL_DIR"/mediawiki
 git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/skins/Vector "$INSTALL_DIR"/mediawiki/skins/Vector
 
-cd "$INSTALL_DIR"/mediawiki
+
+DOCKER_MW_PATH="$INSTALL_DIR"/mediawiki
+
+echo "DOCKER_MW_PATH=$DOCKER_MW_PATH" >> local.env
+
+cd "$DOCKER_MW_PATH"
 docker run -it --rm --user $(id -u):$(id -g) -v $HOME/.composer:/tmp -v $(pwd):/app composer install --ignore-platform-reqs
 touch LocalSettings.php
 cat > LocalSettings.php <<EOL

--- a/setup.sh
+++ b/setup.sh
@@ -4,11 +4,11 @@ set -eu
 mkdir -p "$INSTALL_DIR"
 [[ ! -d $HOME/.composer ]] && mkdir $HOME/.composer
 
-git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/core "$INSTALL_DIR"/mediawiki
-git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/skins/Vector "$INSTALL_DIR"/mediawiki/skins/Vector
-
 
 DOCKER_MW_PATH="$INSTALL_DIR"/mediawiki
+
+git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/core "$DOCKER_MW_PATH"
+git clone --depth 1 https://gerrit.wikimedia.org/r/mediawiki/skins/Vector "$DOCKER_MW_PATH"/skins/Vector
 
 echo "DOCKER_MW_PATH=$DOCKER_MW_PATH" >> local.env
 


### PR DESCRIPTION
To make setup.sh work out the box we should set `DOCKER_MW_PATH` correctly to where we know we did the install in `setup.sh`