### PR TITLE
Allow encoded url slashes

### DIFF
--- a/config/apache/vhost.conf
+++ b/config/apache/vhost.conf
@@ -1,0 +1,1 @@
+AllowEncodedSlashes On

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
      - ./config/mediawiki:/var/www/mediawiki/.docker:ro
      - ./scripts/wait-for-it.sh:/srv/wait-for-it.sh:ro
      - mw-images:/var/www/mediawiki/images/docker:delegated
+     - ./config/apache/vhost.conf:/opt/docker/etc/httpd/vhost.common.d/vhost.conf
   graphite-statsd:
     image: hopsoft/graphite-statsd
     environment:


### PR DESCRIPTION
By default, slashes are not encoded by apache. This
makes it hard to test things like MediaWiki REST endpoints
locally. Set AllowEncodedSlashes 'On' to allow slashes to be encoded.