### PR TITLE
Update PHP Image Tags

### DIFF
--- a/default.env
+++ b/default.env
@@ -10,18 +10,15 @@ WEBSERVER=apache
 
 # PHP Runtime version
 #
-# See <https://github.com/webdevops/Dockerfile/tree/master/docker/php#readme>
+# See <https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-apache-dev.html>
 # for valid values.
 #
 # For example:
-# - 'latest' (alias to ubuntu-18.04)
-# - 'ubuntu-18.04' (Ubuntu 18 Bionic LTS, provides PHP 7.2).
-# - 'ubuntu-16.04' (Ubuntu 16 Xenial LTS, provides PHP 7.0).
-# - '7.4' (based on Debian 9 Stretch)
-# - '7.3' (based on Debian 9 Stretch)
-# - '7.2' (based on Debian 9 Stretch)
-# - '7.1' (based on Debian 9 Stretch)
-RUNTIMEVERSION=latest
+# - '7.4' (based on customized official php image)
+# - '7.3' (based on customized official php image)
+# - '7.2' (based on customized official php image)
+# - '7.1' (based on customized official php image)
+RUNTIMEVERSION=7.4
 
 # XDebug settings
 #


### PR DESCRIPTION
The upstream images have changed the recommended list of tags
The `ubuntu` and `debian` tags are deprecated.
`latest` doesn't appear to be used any more and hasn't been built or pushed to about 1 year.