### PR TITLE
phpunit: move from flags to env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
      - PHP_UPLOAD_MAX_FILESIZE=1024M
      - PHP_POST_MAX_SIZE=1024M
      - php.apc.enable_cli=1
+     - PHPUNIT_WIKI
     hostname: mediawiki.mw.localhost
     dns:
       - 172.0.0.10

--- a/phpunit
+++ b/phpunit
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 # Usage: phpunit WIKINAME --group=Database
 # Example: phpunit default --group=Database
 set -eu
 
-docker-compose exec "web" php //var/www/mediawiki/tests/phpunit/phpunit.php --wiki $@
+PHPUNIT_WIKI=$1
+
+docker-compose exec "web" php //var/www/mediawiki/tests/phpunit/phpunit.php ${*:2}

--- a/phpunit-file
+++ b/phpunit-file
@@ -3,4 +3,6 @@
 # Example: phpunit-file default tests/phpunit/includes/PageArchiveTest.php
 set -eu
 
-docker-compose exec "web" php //var/www/mediawiki/tests/phpunit/phpunit.php --wiki $1 //var/www/mediawiki/${*:2}
+PHPUNIT_WIKI=$1
+
+docker-compose exec "web" php //var/www/mediawiki/tests/phpunit/phpunit.php //var/www/mediawiki/${*:2}


### PR DESCRIPTION
The flags got removed and the phpunit scripts currently fail with
"unrecognized option --wiki". See
https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/thread/T5FTZR7M3RTGJRPYV7SLAVUIT3MXZBXB/